### PR TITLE
Adjusted Padding In Post List

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,9 @@
         background-position: 5px;
         min-height: 110px;
       }
-
+      #recent-episode-list > ul li audio,h4,p {
+        padding-left: 1em;
+      }
       .subscriptions {
         width: 230px;
         margin: 0 auto;


### PR DESCRIPTION
left padding of 1em is added to the title of the post, description and audio player in the recent post list.
the difference in the views can be seen in the images below:

OLD

![old recent posts list](https://cloud.githubusercontent.com/assets/8947356/7150473/0545105c-e339-11e4-8209-89802a0c73f1.PNG)

UPDATED

![updated recent posts list](https://cloud.githubusercontent.com/assets/8947356/7150477/101b8556-e339-11e4-9483-378e02993668.PNG)
